### PR TITLE
patch for mac CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 # Travis (https://travis-ci.org) configuration file
 
+# CI MACOS
+  # brew install xz
+    # without xz ROOT gives: 
+    # "Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0 "
+    # try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
+
 sudo: required
 services:
   - docker
@@ -20,6 +26,7 @@ matrix:
 before_install:
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
       brew update > /dev/null;
+      brew install xz;
       brew install homebrew/science/root;
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;
       source venv/bin/activate;

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,11 @@ before_install:
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;
       source venv/bin/activate;
       source $(brew --prefix root)/libexec/thisroot.sh;
-      which root;
-      cat 'TRY IMPORT ROOT';
-      python -c "import ROOT";
-      otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
-      otool -L root/lib/libPyROOT.so;
       pip install pip -U;
       pip install -r requirements.txt;
       pip install rootpy root_numpy;
-#      mkdir -p $HOME/.matplotlib;
-#      echo 'backend:TkAgg' > $HOME/.matplotlib/matplotlibrc;
+      mkdir -p $HOME/.matplotlib;
+      echo 'backend:TkAgg' > $HOME/.matplotlib/matplotlibrc;
     else
       source ci/install_repbase.sh;
       conda list;

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,13 @@ before_install:
       brew update > /dev/null;
       brew install python;
       brew install homebrew/science/root;
+      source $(brew --prefix root)/libexec/thisroot.sh;
+      python -c 'import ROOT';
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;
       source venv/bin/activate;
       source $(brew --prefix root)/libexec/thisroot.sh;
       which root;
-      cat 'TRY IMPORT ROOT';
+      echo 'TRY IMPORT ROOT';
       python -c 'import ROOT';
       otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
       otool -L root/lib/libPyROOT.so;

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
       brew update > /dev/null;
       brew install python;
       brew install homebrew/science/root;
-      brew install xz
+      brew install xz;
       source $(brew --prefix root)/libexec/thisroot.sh;
       python -c 'import ROOT';
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 # Travis (https://travis-ci.org) configuration file
 # CI MACOS
-# ^^^brew install xz
-# ^^^^^^without xz ROOT gives: 
-# ^^^^^^"Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0 "
-# ^^^^^^try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
+#   brew install xz
+#        without xz ROOT gives: 
+#        'Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0 '
+#        try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
 
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
       source $(brew --prefix root)/libexec/thisroot.sh;
       which root;
       cat 'TRY IMPORT ROOT';
-      python -c "import ROOT";
+      python -c 'import ROOT';
       otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
       otool -L root/lib/libPyROOT.so;
       pip install pip -U;

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,23 @@ matrix:
 before_install:
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
       brew update > /dev/null;
+      # without xz ROOT gives:
+      # Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0
+      # try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
       brew install xz;
-      brew install python;
+      #brew install python;
       brew install homebrew/science/root;
       echo 'python source';
       which python;
       source $(brew --prefix root)/libexec/thisroot.sh;
       python -c 'import ROOT';
       otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
-      sudo install_name_tool -change /System/Library/Frameworks/Python.framework/Versions/2.7/Python /usr/local/Frameworks/Python.framework/Versions/2.7/Python $(brew --prefix root)/lib/root/libPyROOT.so;
-      otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
-      python -c 'import ROOT';
+      # "brew install xz" gives:
+      # Fatal Python error: PyThreadState_Get: no current thread
+      # to fix this change source of python for PyROOT from system python to brew python
+      #sudo install_name_tool -change /System/Library/Frameworks/Python.framework/Versions/2.7/Python /usr/local/Frameworks/Python.framework/Versions/2.7/Python $(brew --prefix root)/lib/root/libPyROOT.so;
+      #otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
+      #python -c 'import ROOT';
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;
       source venv/bin/activate;
       source $(brew --prefix root)/libexec/thisroot.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ before_install:
       brew install xz;
       brew install python;
       brew install homebrew/science/root;
+      echo 'python source';
+      which python;
       source $(brew --prefix root)/libexec/thisroot.sh;
       python -c 'import ROOT';
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;
@@ -32,7 +34,6 @@ before_install:
       echo 'TRY IMPORT ROOT';
       python -c 'import ROOT';
       otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
-      otool -L root/lib/libPyROOT.so;
       pip install pip -U;
       pip install -r requirements.txt;
       pip install rootpy root_numpy;

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,16 @@ before_install:
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;
       source venv/bin/activate;
       source $(brew --prefix root)/libexec/thisroot.sh;
+      which root;
+      cat 'TRY IMPORT ROOT';
+      python -c "import ROOT";
+      otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
+      otool -L root/lib/libPyROOT.so;
       pip install pip -U;
       pip install -r requirements.txt;
       pip install rootpy root_numpy;
-      mkdir -p $HOME/.matplotlib;
-      echo 'backend:TkAgg' > $HOME/.matplotlib/matplotlibrc;
+#      mkdir -p $HOME/.matplotlib;
+#      echo 'backend:TkAgg' > $HOME/.matplotlib/matplotlibrc;
     else
       source ci/install_repbase.sh;
       conda list;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 # Travis (https://travis-ci.org) configuration file
 # CI MACOS
+# ^^^brew install xz
+# ^^^^^^without xz ROOT gives: 
+# ^^^^^^"Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0 "
+# ^^^^^^try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
 
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,23 +20,13 @@ matrix:
 before_install:
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
       brew update > /dev/null;
-      # without xz ROOT gives:
-      # Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0
-      # try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
       brew install xz;
-      # brew install python;
       brew install homebrew/science/root;
       echo 'python source';
       which python;
       source $(brew --prefix root)/libexec/thisroot.sh;
       python -c 'import ROOT';
       otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
-      # "brew install xz" gives:
-      # Fatal Python error: PyThreadState_Get: no current thread
-      # to fix this change source of python for PyROOT from system python to brew python
-      # sudo install_name_tool -change /System/Library/Frameworks/Python.framework/Versions/2.7/Python /usr/local/Frameworks/Python.framework/Versions/2.7/Python $(brew --prefix root)/lib/root/libPyROOT.so;
-      # otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
-      # python -c 'import ROOT';
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;
       source venv/bin/activate;
       source $(brew --prefix root)/libexec/thisroot.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,16 @@ before_install:
       which python;
       source $(brew --prefix root)/libexec/thisroot.sh;
       python -c 'import ROOT';
+      otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
+      sudo install_name_tool -change /System/Library/Frameworks/Python.framework/Versions/2.7/Python /usr/local/Frameworks/Python.framework/Versions/2.7/Python $(brew --prefix root)/lib/root/libPyROOT.so;
+      otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
+      python -c 'import ROOT';
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;
       source venv/bin/activate;
       source $(brew --prefix root)/libexec/thisroot.sh;
       which root;
       echo 'TRY IMPORT ROOT';
       python -c 'import ROOT';
-      otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
       pip install pip -U;
       pip install -r requirements.txt;
       pip install rootpy root_numpy;

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ matrix:
 before_install:
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
       brew update > /dev/null;
+      brew install xz;
       brew install python;
       brew install homebrew/science/root;
-      brew install xz;
       source $(brew --prefix root)/libexec/thisroot.sh;
       python -c 'import ROOT';
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 # Travis (https://travis-ci.org) configuration file
 # CI MACOS
-#   brew install xz
-#        without xz ROOT gives: 
-#        'Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0 '
-#        try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
+# -brew install xz
+# --without xz ROOT gives: 
+# ---Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0 
+# ---try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
 
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 # Travis (https://travis-ci.org) configuration file
 
 # CI MACOS
-  # brew install xz
-    # without xz ROOT gives: 
-    # "Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0 "
-    # try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
+#   brew install xz
+#        without xz ROOT gives: 
+#        "Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0 "
+#        try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
 
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ before_install:
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;
       source venv/bin/activate;
       source $(brew --prefix root)/libexec/thisroot.sh;
+      which root;
+      cat 'TRY IMPORT ROOT';
+      python -c "import ROOT";
+      otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
+      otool -L root/lib/libPyROOT.so;
       pip install pip -U;
       pip install -r requirements.txt;
       pip install rootpy root_numpy;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-# Travis (https://travis-ci.org) configuration file
 # CI MACOS
 #   brew install xz
 #        without xz ROOT gives: 
 #        "Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0 "
 #        try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
+# Travis (https://travis-ci.org) configuration file
 
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
       # Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0
       # try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
       brew install xz;
-      #brew install python;
+      # brew install python;
       brew install homebrew/science/root;
       echo 'python source';
       which python;
@@ -34,9 +34,9 @@ before_install:
       # "brew install xz" gives:
       # Fatal Python error: PyThreadState_Get: no current thread
       # to fix this change source of python for PyROOT from system python to brew python
-      #sudo install_name_tool -change /System/Library/Frameworks/Python.framework/Versions/2.7/Python /usr/local/Frameworks/Python.framework/Versions/2.7/Python $(brew --prefix root)/lib/root/libPyROOT.so;
-      #otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
-      #python -c 'import ROOT';
+      # sudo install_name_tool -change /System/Library/Frameworks/Python.framework/Versions/2.7/Python /usr/local/Frameworks/Python.framework/Versions/2.7/Python $(brew --prefix root)/lib/root/libPyROOT.so;
+      # otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
+      # python -c 'import ROOT';
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;
       source venv/bin/activate;
       source $(brew --prefix root)/libexec/thisroot.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,7 @@ script:
       THEANO_FLAGS='gcc.cxxflags="-march=core2"' nosetests -v --detailed-errors --nocapture ./tests/test_*;
     fi
   # testing only notebooks
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-      nosetests -v --detailed-errors --nocapture --stop ./tests/z_test_*;
-    else
+  - if [[ $TRAVIS_OS_NAME != 'osx' ]]; then
       THEANO_FLAGS='gcc.cxxflags="-march=core2"' nosetests -v --detailed-errors --nocapture --stop ./tests/z_test_*;
     fi
   # if on master and tests passed successfully, trigger rebuilding of docker image.

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,10 @@ matrix:
 before_install:
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
       brew update > /dev/null;
-      brew install xz;
       brew install homebrew/science/root;
-      echo 'python source';
-      which python;
-      source $(brew --prefix root)/libexec/thisroot.sh;
-      python -c 'import ROOT';
-      otool -L $(brew --prefix root)/lib/root/libPyROOT.so;
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;
       source venv/bin/activate;
       source $(brew --prefix root)/libexec/thisroot.sh;
-      which root;
       echo 'TRY IMPORT ROOT';
       python -c 'import ROOT';
       pip install pip -U;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 # Travis (https://travis-ci.org) configuration file
+# CI MACOS
+#   brew install xz
+#        without xz ROOT gives: 
+#        "Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0 "
+#        try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
 
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 # Travis (https://travis-ci.org) configuration file
 
-# CI MACOS
-#   brew install xz
-#        without xz ROOT gives: 
-#        "Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0 "
-#        try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
-
 sudo: required
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
-# CI MACOS
-#   brew install xz
-#        without xz ROOT gives: 
-#        "Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0 "
-#        try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
 # Travis (https://travis-ci.org) configuration file
+# CI MACOS
 
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
       brew update > /dev/null;
       brew install python;
       brew install homebrew/science/root;
+      brew install xz
       source $(brew --prefix root)/libexec/thisroot.sh;
       python -c 'import ROOT';
       virtualenv venv -p python$TRAVIS_PYTHON_VERSION;

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
     fi
   # testing only notebooks
   - if [[ $TRAVIS_OS_NAME != 'osx' ]]; then
-      THEANO_FLAGS='gcc.cxxflags="-march=core2"' nosetests -v --detailed-errors --nocapture --stop ./tests/z_test_*;
+      nosetests -v --detailed-errors --nocapture --stop ./tests/z_test_*;
     fi
   # if on master and tests passed successfully, trigger rebuilding of docker image.
   - if [[ "$TRAVIS_BRANCH" = "master" && "${TRAVIS_PYTHON_VERSION:0:1}" = "2" ]] ; then make push-latest ; fi

--- a/rep/estimators/theanets.py
+++ b/rep/estimators/theanets.py
@@ -299,7 +299,7 @@ class TheanetsClassifier(TheanetsBase, Classifier):
             self.exp = tnt.Experiment(tnt.Classifier, layers=layers, weighted=True)
         params = self._prepare_network_params()
         params.update(**trainer)
-        if trainer.get('optimize', None) == 'pretrain':
+        if trainer.get('algo', None) == 'pretrain':
             self.exp.train([X.astype(numpy.float32)], **params)
         else:
             self.exp.train([X.astype(numpy.float32), y.astype(numpy.int32), sample_weight.astype(numpy.float32)],

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ ipython[all] == 4.0.0
 bokeh == 0.11.1
 mpld3 == 0.2
 neurolab == 0.3.5
-theanets == 0.6.2
+theano == 0.8.2
+nose-parameterized == 0.5.0
+theanets == 0.7.3
 pybrain == 0.3
 xgboost == 0.4a30


### PR DESCRIPTION
* update theanets to 0.7.3;
* fix theano version 0.8.2 (depend on nose-parameterized -> add to requirements);
* error in import root: 
   * without xz ROOT gives:  ```Incompatible library version: libCore.so requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0```
   * try to solve by https://github.com/Homebrew/legacy-homebrew/issues/42209 installing xz
   * add ```brew install xz```
* remove ```brew install python``` (brew install root now doesn't install python from brew -> PyROOT depends on system python, this can be check by
```otool -L $(brew --prefix root)/lib/root/libPyROOT.so```). 
* With non system python PyROOT will work if do the following:
``` 
brew install python;
brew install root;
sudo install_name_tool -change /System/Library/Frameworks/Python.framework/Versions/2.7/Python /usr/local/Frameworks/Python.framework/Versions/2.7/Python $(brew --prefix root)/lib/root/libPyROOT.so;
```