### PR TITLE
fix version of ipykernel==4.3.1

### DIFF
--- a/ci/environment-rep-template.yaml
+++ b/ci/environment-rep-template.yaml
@@ -14,6 +14,7 @@ dependencies:
   - rootpy
   - root=5*
   - pip:
+    - ipykernel==4.3.1
     - notebook==4.2.1
     - bokeh==0.11.1
     - neurolab==0.3.5

--- a/ci/environment-rep2.yaml
+++ b/ci/environment-rep2.yaml
@@ -15,6 +15,7 @@ dependencies:
   - rootpy
   - root=5*
   - pip:
+    - ipykernel==4.3.1
     - notebook==4.2.1
     - bokeh==0.11.1
     - neurolab==0.3.5

--- a/ci/environment-rep3.yaml
+++ b/ci/environment-rep3.yaml
@@ -15,6 +15,7 @@ dependencies:
   - rootpy
   - root=5*
   - pip:
+    - ipykernel==4.3.1
     - notebook==4.2.1
     - bokeh==0.11.1
     - neurolab==0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ scipy >= 0.16.0
 matplotlib == 1.5.1
 pandas == 0.17.1
 scikit-learn == 0.17.1
+ipykernel == 4.3.1
 notebook == 4.2.1
 bokeh == 0.11.1
 mpld3 == 0.2


### PR DESCRIPTION
fix version of ipykernel==4.3.1 to work with matplotlib: version 4.4.0 doesn't work with matplotlib, see issue http://stackoverflow.com/questions/38838914/failure-to-import-matplotlib-pyplot-in-jupyter-but-not-ipython.