### PR TITLE
Update lib

### DIFF
--- a/rep/metaml/folding.py
+++ b/rep/metaml/folding.py
@@ -10,7 +10,7 @@ import pandas
 from six.moves import zip
 
 from sklearn import clone
-from sklearn.cross_validation import KFold
+from sklearn.model_selection import KFold
 from sklearn.utils import check_random_state
 from . import utils
 from .factory import train_estimator


### PR DESCRIPTION
Issue:

ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-29-283853cb69dc> in <module>
      5 from sklearn.ensemble import  HistGradientBoostingClassifier
      6 from rep.report.metrics import RocAuc
----> 7 from rep.metaml import GridOptimalSearchCV, FoldingScorer, RandomParameterOptimizer
      8 from rep.estimators import SklearnClassifier

~/.local/lib/python3.8/site-packages/rep/metaml/__init__.py in <module>
      2 
      3 from .factory import ClassifiersFactory, RegressorsFactory
----> 4 from .folding import FoldingClassifier, FoldingRegressor
      5 from .gridsearch import GridOptimalSearchCV
      6 from .stacking import FeatureSplitter

~/.local/lib/python3.8/site-packages/rep/metaml/folding.py in <module>
     11 
     12 from sklearn import clone
---> 13 from sklearn.cross_validation import KFold
     14 from sklearn.utils import check_random_state
     15 from . import utils

ModuleNotFoundError: No module named 'sklearn.cross_validation'

Correction suggested based on https://stackoverflow.com/questions/30667525/importerror-no-module-named-sklearn-cross-validation  
